### PR TITLE
Fix crossfader

### DIFF
--- a/lib/apc40.js
+++ b/lib/apc40.js
@@ -84,8 +84,8 @@ function APC40( midi_in, midi_out ) {
 		// Crossfader change ( a/b mode )
 		if ( isControl( status ) && data1 === 0x0f ) {
 			var crossfader = {
-				"a": ( data2 <= 64 ? 127 : 254 - data2 * 2 ),
-				"b": ( data2 >= 64 ? 127 : data2 * 2 ),
+				"a": 127 - data2,
+				"b": data2,
 				"value": data2
 			};
 			if ( data2 > state.crossfader ) crossfader.assign_a = true;


### PR DESCRIPTION
The current crossfader adds both signals when the fader is in the middle and the overall sound is louder.
I didn't test the code but I'm assuming that:
* data2 is a value in the interval [0,127]
* a and b should be a value in the interval [0,127] where the sum is always 127